### PR TITLE
Explicitly select version of bootstrap-maxlength.js

### DIFF
--- a/TwbsMaxlength.php
+++ b/TwbsMaxlength.php
@@ -27,6 +27,11 @@ class TwbsMaxlength extends InputWidget
 	const THRESHOLD_THREE_QUARTERS = 3;
 	
 	/**
+	* @var boolean use minified version of bootstrap-maxlength.js
+	*/
+	public $minifyJs = false;
+	
+	/**
 	 * @var string JQuery selector to attach the maxlength widget to. If this option is set, it is used 
 	 * in priority. It must be empty when the widget is used with ActiveField.
 	 */
@@ -128,6 +133,7 @@ class TwbsMaxlength extends InputWidget
 	public function registerClientScript()
 	{
 		$view = $this->getView();
+		TwbsMaxlengthAsset::$minifyJs = $this->minifyJs;
 		TwbsMaxlengthAsset::register($view);
 
 		$options = empty($this->clientOptions) ? "{}" : Json::encode($this->clientOptions);

--- a/TwbsMaxlengthAsset.php
+++ b/TwbsMaxlengthAsset.php
@@ -12,13 +12,18 @@ class TwbsMaxlengthAsset extends AssetBundle
 	public $depends = [
 		'yii\web\JqueryAsset'
 	];
+	
+	/**
+	* @var boolean use minified version of bootstrap-maxlength.js
+	*/
+	public static $minifyJs = false;
 	/**
 	 * @see \yii\web\AssetBundle::init()
 	 */
 	public function init()
 	{
 		$this->js = [
-			'bootstrap-maxlength'.( YII_ENV_DEV ? '.js' : '.min.js' )
+			'bootstrap-maxlength'.( $minifyJs ? '.min.js' : '.js' )
 		];
 		return parent::init();
 	}


### PR DESCRIPTION
Choosing min version by global const was unexpected harmful dependancy for my project.

So I've added widget public attribute $minifyJs in order to explicitly select version of bootstrap-maxlength.js (min/origin).

I think it may by usfull for others 

